### PR TITLE
Fix: Change Invoice Amount (With VAT) to Grand Total

### DIFF
--- a/ksa_vat/events/accounts/sales_invoice.py
+++ b/ksa_vat/events/accounts/sales_invoice.py
@@ -76,7 +76,7 @@ def create_qr_code(doc, method):
 			tlv_array.append(''.join([tag, length, value]))
 
 			# Invoice Amount
-			invoice_amount = str(doc.total)
+			invoice_amount = str(doc.grand_total)
 			tag = bytes([4]).hex()
 			length = bytes([len(invoice_amount)]).hex()
 			value = invoice_amount.encode('utf-8').hex()


### PR DESCRIPTION
Change Invoice amount (With VAT) to grand total as per ZATCA requirement